### PR TITLE
Fix build for base64 utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
-base64.o
-base64_avx2.o
-base64_neon.o
-base64_neon64.o
-base64_ssse3.o
-base64_std.o
-cpufeatures.o
+*.o
 libbase64.a
 base64
 base64.dSYM

--- a/Makefile
+++ b/Makefile
@@ -8,25 +8,41 @@ AVX2_CFLAGS = -mavx2
 NEON_CFLAGS =
 NEON64_CFLAGS =
 
+OBJS = \
+  base64.o \
+  base64_avx2.o \
+  base64_neon.o \
+  base64_neon64.o \
+  base64_ssse3.o \
+  base64_std.o \
+  cpufeatures.o
+
 all: base64 libbase64.a
 
-base64: main.c base64.c base64_std.c base64_ssse3.c base64_avx2.c base64_neon.c base64_neon64.c cpufeatures.c
-	$(CC) $(CFLAGS) -o $@ $^
+base64: main.o libbase64.a
+	$(CC) $(LDFLAGS) -o $@ $^
 
-libbase64.a: main.c base64.c base64_std.c base64_ssse3.c base64_avx2.c base64_neon.c base64_neon64.c cpufeatures.c
-	$(CC) $(CFLAGS) -c base64.c
-	$(CC) $(CFLAGS) -c base64_std.c
-	$(CC) $(CFLAGS) $(SSSE3_CFLAGS) -c base64_ssse3.c
-	$(CC) $(CFLAGS) $(AVX2_CFLAGS) -c base64_avx2.c
-	$(CC) $(CFLAGS) $(NEON_CFLAGS) -c base64_neon.c
-	$(CC) $(CFLAGS) $(NEON64_CFLAGS) -c base64_neon64.c
-	$(CC) $(CFLAGS) -c cpufeatures.c
+libbase64.a: $(OBJS)
 ifeq ($(UNAME_S),Darwin)
-	$(LIBTOOL) -static base64.o base64_std.o base64_ssse3.o base64_avx2.o base64_neon.o base64_neon64.o cpufeatures.o -o libbase64.a
+	$(LIBTOOL) -static $(OBJS) -o $@
 else
-	$(AR) -r libbase64.a base64.o base64_std.o base64_ssse3.o base64_avx2.o base64_neon.o base64_neon64.o cpufeatures.o
+	$(AR) -r $@ $(OBJS)
 endif
 
+base64_avx2.o: base64_avx2.c
+	$(CC) $(CFLAGS) $(AVX2_CFLAGS) -o $@ -c $^
+
+base64_neon.o: base64_neon.c
+	$(CC) $(CFLAGS) $(NEON_CFLAGS) -o $@ -c $^
+
+base64_neon64.o: base64_neon64.c
+	$(CC) $(CFLAGS) $(NEON64_CFLAGS) -o $@ -c $^
+
+base64_ssse3.o: base64_ssse3.c
+	$(CC) $(CFLAGS) $(SSSE3_CFLAGS) -o $@ -c $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -o $@ -c $^
 
 .PHONY: clean analyze
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -5,8 +5,11 @@ CFLAGS += -std=c89 -O3 -Wall -Wextra -pedantic
 test: clean test_base64
 	./test_base64
 
-test_base64: test_base64.c ../base64.c
+test_base64: test_base64.c ../libbase64.a
 	$(CC) $(CFLAGS) -o $@ $^
+
+../%:
+	make -C .. $*
 
 clean:
 	rm -f test_base64


### PR DESCRIPTION
The base64 test utility was not building correctly; all its codecs were being built without the proper architecture flags. Also fix the testcase build; it should be linked to all the codec object files.
